### PR TITLE
cmake: add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,13 @@ set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
 file(GLOB SOURCES *.c *.h "demo/*.c" "demo/*.h")
 
 add_executable(gpmf-writer ${SOURCES})
+
+
+file(GLOB HEADERS *.h)
+file(GLOB CFILES *.c)
+
+install(FILES ${HEADERS} DESTINATION include/gpmf-write)
+
+add_library(gpmf-write SHARED ${HEADERS} ${CFILES})
+set_property(TARGET gpmf-write PROPERTY SOVERSION 1)
+install(TARGETS gpmf-write DESTINATION lib)


### PR DESCRIPTION
Adds an install target to CMakelists.txt, so that the project can be installed easily with `make install`.

This is for instance useful when building the project with [Yocto](https://www.yoctoproject.org/).