### PR TITLE
Fixing interlock when activating flag GPMF_FLAGS_STORE_ALL_TIMESTAMPS

### DIFF
--- a/GPMF_writer.c
+++ b/GPMF_writer.c
@@ -596,7 +596,7 @@ void AppendFormattedMetadata(device_metadata *dm, uint32_t *formatted, uint32_t 
 		uint32_t swap64timestamp[2];
 		uint64_t *ptr64 = (uint64_t *)&swap64timestamp[0];
 		uint32_t buf[5];
-		uint32_t stampflags = (flags & GPMF_FLAGS_LOCKED) | GPMF_FLAGS_DONT_COUNT;
+		uint32_t stampflags = flags | GPMF_FLAGS_LOCKED | GPMF_FLAGS_DONT_COUNT;
 
 		*ptr64 = BYTESWAP64(TimeStamp);		
 	//	TimeStamp = 0;  // with this commented out it will store both jitter removed and raw timestamps.


### PR DESCRIPTION
Fixes #11 
The lock flag was not correctly added to the `stampflags` variable causing an interlock on the recursive call. 

@dnewman-gpsw  Could you please review this patch. 